### PR TITLE
Updates to PR #468 (phenology status timers)

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -193,8 +193,8 @@ contains
     integer  :: dstat      ! drought status phenology flag
     real(r8) :: acc_NI
     real(r8) :: watermem 
-    real(r8) :: cleafon    ! DOY for cold-decid leaf-on, initial guess
-    real(r8) :: cleafoff   ! DOY for cold-decid leaf-off, initial guess
+    integer  :: cleafon    ! DOY for cold-decid leaf-on, initial guess
+    integer  :: cleafoff   ! DOY for cold-decid leaf-off, initial guess
     integer  :: dleafoff   ! DOY for drought-decid leaf-off, initial guess
     integer  :: dleafon    ! DOY for drought-decid leaf-on, initial guess
     !----------------------------------------------------------------------
@@ -208,8 +208,8 @@ contains
     if ( hlm_is_restart == ifalse ) then
 
        GDD      = 30.0_r8
-       cleafon  = 100.0_r8
-       cleafoff = 300.0_r8 
+       cleafon  = 100
+       cleafoff = 300 
        cstat    = 2                ! Leaves are on
        acc_NI   = 0.0_r8
        dstat    = 2                ! Leaves are on

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -630,7 +630,7 @@ module EDTypesMod
      integer  ::  cleafondate                                  ! model date (day integer) of leaf on (cold):-
      integer  ::  cleafoffdate                                 ! model date (day integer) of leaf off (cold):-
      integer  ::  dleafondate                                  ! model date (day integer) of leaf on drought:-
-     integer  ::  dleafoffdate                                 ! model date (day integer) of leaf on drought:-
+     integer  ::  dleafoffdate                                 ! model date (day integer) of leaf off drought:-
 
      real(r8) ::  water_memory(numWaterMem)                             ! last 10 days of soil moisture memory...
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1165,7 +1165,6 @@ end subroutine flush_hvars
     ! locals
     integer :: ub1, lb1, ub2, lb2    ! Bounds for allocating the var
     integer :: ityp
-    integer :: nonfates              ! non-optional 
 
     logical :: write_var
 


### PR DESCRIPTION
Fixed a few typos and some artifacts where `itrue` was changed to 1.  Refactored the `cstatus` and `dstatus` checks to use any for a few cases.  There might be more we can change.

Fixes: PR #468

User interface changes?: No

Code review: Ryan Knox

Testing: none, not expected to compile

<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
@rgknox 

### Expectation of Answer Changes:
Should be B4B.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

