### PR TITLE
Rosie colddec

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -697,6 +697,7 @@ contains
          (currentSite%nchilldays >= 1)) then
        currentSite%cstatus = phen_cstat_notcold  ! Set to not-cold status (leaves can come on)
        currentSite%cleafondate = model_day_int  
+        dayssincecleafon = 0 !rezero this so that the leaves don't immediately fall off again! 
        if ( debug ) write(fates_log(),*) 'leaves on'
     endif !GDD
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -715,6 +715,7 @@ contains
     if ( (currentSite%cstatus == phen_cstat_iscold .or. &
           currentSite%cstatus == phen_cstat_nevercold) .and. &
          (currentSite%grow_deg_days > gdd_threshold) .and. &
+         (dayssincecleafoff > ED_val_phen_mindayson) .and. &
          (currentSite%nchilldays >= 1)) then
        currentSite%cstatus = phen_cstat_notcold  ! Set to not-cold status (leaves can come on)
        currentSite%cleafondate = model_day_int  

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -907,7 +907,7 @@ contains
     real(r8) :: store_c_transfer_frac  ! Fraction of storage carbon used to flush leaves
     integer  :: ipft
     real(r8), parameter :: leaf_drop_fraction = 1.0_r8
-
+    real(r8), parameter :: carbon store buffer = 0.10_r8
     !------------------------------------------------------------------------
 
     currentPatch => CurrentSite%oldest_patch   
@@ -936,8 +936,11 @@ contains
                                                                 ! stop flow of carbon out of bstore. 
                    
                    if(store_c>nearzero) then
-                      store_c_transfer_frac = &
-                            min(EDPftvarcon_inst%phenflush_fraction(ipft)*currentCohort%laimemory, store_c)/store_c
+                   ! flush either the amount required from the laimemory, or -most- of the storage pool
+                   ! RF: added a criterium to stop the entire store pool emptying and triggering termination mortality
+                   ! n.b. this might not be necessary if we adopted a more gradual approach to leaf flushing... 
+                       store_c_transfer_frac =  min((EDPftvarcon_inst%phenflush_fraction(ipft)* &
+                            currentCohort%laimemory)/store_c,(1.0_r8-carbon_store_buffer))
                    else
                       store_c_transfer_frac = 0.0_r8
                    end if

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -698,6 +698,7 @@ contains
          (currentSite%nchilldays >= 1)) then
        currentSite%cstatus = phen_cstat_notcold  ! Set to not-cold status (leaves can come on)
        currentSite%cleafondate = model_day_int  
+       dayssincecleafon = 0 
        if ( debug ) write(fates_log(),*) 'leaves on'
     endif !GDD
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -662,10 +662,30 @@ contains
     !
     ! accumulate the GDD using daily mean temperatures
     ! Don't accumulate GDD during the growing season (that wouldn't make sense)
-    if (bc_in%t_veg24_si .gt. tfrz) then
+    if (bc_in%t_veg24_si .gt. tfrz.and. currentSite%cstatus == phen_cstat_iscold) then
        currentSite%grow_deg_days = currentSite%grow_deg_days + bc_in%t_veg24_si - tfrz
     endif
     
+    !this logic is to prevent GDD accumulating after the leaves have fallen and before the 
+    ! beginnning of the accumulation period, to prevend erroneous autumn leaf flushing. 
+    if(model_day_int>365)then !only do this after the first year to prevent odd behaviour
+
+    if(currentSite%lat .gt. 0.0_r8)then !Northern Hemisphere                                           
+      ! In the north, don't accumulate when we are past the leaf fall date.
+      ! Accumulation starts on day 1 of year in NH.  
+      ! The 180 is to prevent going into an 'always off' state after initialization
+      if( model_day_int .gt. currentSite%cleafoffdate.and.hlm_day_of_year.gt.180)then !
+       currentSite%grow_deg_days = 0._r8
+      endif
+     else !Southern Hemisphere 
+      ! In the South, don't accumulate after the leaf off date, and before the start of
+      ! the accumulation phase (day 181).  
+      if(model_day_int .gt. currentSite%cleafoffdate.and.hlm_day_of_year.lt.gddstart) then! 
+        currentSite%grow_deg_days = 0._r8
+      endif
+    endif
+    endif !year1 
+
     ! Calculate the number of days since the leaves last came on 
     ! and off. If this is the beginning of the simulation, that day might
     ! not had occured yet, so set it to last year to get things rolling
@@ -699,6 +719,7 @@ contains
        currentSite%cstatus = phen_cstat_notcold  ! Set to not-cold status (leaves can come on)
        currentSite%cleafondate = model_day_int  
        dayssincecleafon = 0 
+       currentSite%grow_deg_days = 0._r8 ! zero GDD for the rest of the year until counting season begins. 
        if ( debug ) write(fates_log(),*) 'leaves on'
     endif !GDD
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -1172,7 +1172,7 @@ data:
 
  fates_phen_drought_threshold = 0.15 ;
 
- fates_phen_mindayson = 30 ;
+ fates_phen_mindayson = 90 ;
 
  fates_phen_ncolddayslim = 5 ;
 


### PR DESCRIPTION
<!--- This is a series of updates that resolve a set of issues uncovered in the cold deciduous phenology routine.-->

### Description:
<!--- There are several nested changes including
1. Modification of the leaf flushing logic to prevent termination of cohorts with zero stored carbon 
2. Zeroing out dayssinceleafon to prevent the immediate loss of leaves following leaf flushing. 
3. Modification of the growing degree days logic to 
a) prevent accumulation during the growing season
b) prevent accumulation in the autumn before the beginning of the counting period
c) zero out the GDD after leafon occurs. 
4. Extension of the minimum leafon period from 30 to 90 days to prevent erroneous spring leaf loss
5. Addition of a new minimum period for leaf OFF with the same counter as leaf on (this should perhaps be a different counter?) to prevent erroneous re-flushing int he autumn.

I hope that's all!

Also, having messed up my workflow, I had to make all of these commits twice, so ignore the first three commits - they are repeated in the second three... Still working out how to know which commit I've built each of my cases with :/ 

 -->
<!--- These changes cover issue #574 -->

### Collaborators:
<!--- @rgknox @ckoven ->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- This will substantially change answers for cold deciduous phenology plants. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

