### PR TITLE
merging Jessie's mort age parameters

### DIFF
--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -4,6 +4,7 @@ dimensions:
 	fates_history_age_bins = 7 ;
 	fates_history_height_bins = 6 ;
 	fates_history_size_bins = 13 ;
+	fates_history_coage_bins = - ;
 	fates_hydr_organs = 4 ;
 	fates_leafage_class = 1 ;
 	fates_litterclass = 6 ;
@@ -21,6 +22,9 @@ variables:
 	double fates_history_sizeclass_bin_edges(fates_history_size_bins) ;
 		fates_history_sizeclass_bin_edges:units = "cm" ;
 		fates_history_sizeclass_bin_edges:long_name = "Lower edges for DBH size class bins used in size-resolved cohort history output" ;
+	double fates_history_coageclass_bin_edges(fates_history_coage_bins) ;
+	        fates_history_coageclass_bin_edges:units = "years" ;
+		fates_history_coageclass_bin_edges:long_name = "Lower edges for cohort age class bins used in cohort age resolved history output" ;	
 	char fates_pftname(fates_pft, fates_string_length) ;
 		fates_pftname:units = "unitless - string" ;
 		fates_pftname:long_name = "Description of plant type" ;
@@ -297,6 +301,18 @@ variables:
 	double fates_mort_bmort(fates_pft) ;
 		fates_mort_bmort:units = "1/yr" ;
 		fates_mort_bmort:long_name = "background mortality rate" ;
+	double fates_mort_ip_senescence(fates_pft);
+                fates_mort_ip_senescence:units = "dbh cm";
+                fates_mort_ip_senescence:long_name ="Mortality dbh senescence inflection point";
+        double fates_mort_r_senescence(fates_pft);
+                fates_mort_r_senescence:units = "mortality rate dbh^-1";
+                fates_mort_r_senescence:long_name = "Mortality dbh senescence rate of change";
+	double fates_mort_ip_age_senescence(fates_pft);
+                fates_mort_ip_age_senescence:units = "years";
+                fates_mort_ip_age_senescence:long_name ="Mortality cohort age senescence inflection point";
+        double fates_mort_r_age_senescence(fates_pft);
+                fates_mort_r_age_senescence:units = "mortality rate year^-1";
+                fates_mort_r_age_senescence:long_name = "Mortality age senescence rate of change";	
 	double fates_mort_freezetol(fates_pft) ;
 		fates_mort_freezetol:units = "NA" ;
 		fates_mort_freezetol:long_name = "minimum temperature tolerance (NOT USED)" ;
@@ -516,6 +532,9 @@ variables:
 	double fates_cohort_fusion_tol ;
 		fates_cohort_fusion_tol:units = "unitless" ;
 		fates_cohort_fusion_tol:long_name = "minimum fraction in difference in dbh between cohorts" ;
+	double fates_cohort_age_fusion_tol ;
+	        fates_cohort_age_fusion_tol:units = "unitless" ;
+		fates_cohort_age_fusion_tol:long_name = "minimum fraction in differece in cohort age between cohorts" ;	
 	double fates_comp_excln ;
 		fates_comp_excln:units = "none" ;
 		fates_comp_excln:long_name = "weighting factor (exponent on dbh) for canopy layer exclusion and promotion" ;
@@ -656,6 +675,8 @@ data:
 
  fates_history_sizeclass_bin_edges = 0, 5, 10, 15, 20, 30, 40, 50, 60, 70, 
     80, 90, 100 ;
+
+fates_history_coageclass_bin_edges = - ;
 
  fates_pftname =
   "broadleaf_evergreen_tropical_tree          ",
@@ -957,6 +978,14 @@ data:
  fates_mort_bmort = 0.014, 0.014, 0.014, 0.014, 0.014, 0.014, 0.014, 0.014, 
     0.014, 0.014, 0.014, 0.014 ;
 
+ fates_mort_ip_senescence = -, -, -, -, -, -, -, -, -, -, -, - ;
+
+ fates_mort_r_senescence = -, -, -, -, -, -, -, -, -, -, -, - ;
+
+ fates_mort_ip_age_senescence = -, -, -, -, -, -, -, -, -, -, -, - ;
+
+ fates_mort_r_age_senescence = -, -, -, -, -, -, -, -, -, -, -, - ;
+
  fates_mort_freezetol = 2.5, -55, -80, -30, 2.5, -30, -60, -10, -80, -80, 
     -20, 2.5 ;
 
@@ -1190,6 +1219,8 @@ data:
  fates_canopy_closure_thresh = 0.8 ;
 
  fates_cohort_fusion_tol = 0.08 ;
+
+ fates_cohort_age_fusion_tol = - ;
 
  fates_comp_excln = 3 ;
 


### PR DESCRIPTION

Size and age-dependent mortality functions each have two params -
a rate and an inflection point. These are named mort-ip-senescence and
mort-r-senescence with the addition of 'age' for age-dependent mortality.
Cohort age has to be tracked - so history cohort age bins are defined.
Cohorts cannot be fused if similar ages - so there is a cohort age fusion
tolerance parameter.