### PR TITLE
Calibration branch api31 adding day length factor switch

### DIFF
--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -186,7 +186,7 @@ integer, parameter, public :: maxpft = 16      ! maximum number of PFTs allowed
    character(len=param_string_length),parameter,public :: ED_name_patch_fusion_tol= "fates_patch_fusion_tol"
    character(len=param_string_length),parameter,public :: ED_name_canopy_closure_thresh= "fates_canopy_closure_thresh"      
    character(len=param_string_length),parameter,public :: ED_name_stomatal_model= "fates_leaf_stomatal_model"
-   character(len=param_string_length),parameter,public :: ED_name_dayl_switch= "fates_dayl_switch"
+   character(len=param_string_length),parameter,public :: ED_name_dayl_switch= "fates_daylength_factor_switch"
    character(len=param_string_length),parameter,public :: ED_name_regeneration_model= "fates_regeneration_model"
 
    character(len=param_string_length),parameter,public :: name_theta_cj_c3 = "fates_leaf_theta_cj_c3"

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -71,6 +71,7 @@ module EDParamsMod
    real(r8),protected, public :: ED_val_patch_fusion_tol              ! minimum fraction in difference in profiles between patches
    real(r8),protected, public :: ED_val_canopy_closure_thresh         ! site-level canopy closure point where trees take on forest (narrow) versus savannah (wide) crown allometry
    integer,protected, public  :: stomatal_model                       ! switch for choosing between stomatal conductance models, 1 for Ball-Berry, 2 for Medlyn
+   integer,protected, public  :: dayl_switch                          ! switch for turning on or off day length factor scaling for photosynthetic parameters 
    integer,protected, public  :: regeneration_model                   ! Switch for choosing between regeneration models:
                                                                       ! (1) for Fates default
                                                                       ! (2) for the Tree Recruitment Scheme (Hanbury-Brown et al., 2022)
@@ -185,6 +186,7 @@ integer, parameter, public :: maxpft = 16      ! maximum number of PFTs allowed
    character(len=param_string_length),parameter,public :: ED_name_patch_fusion_tol= "fates_patch_fusion_tol"
    character(len=param_string_length),parameter,public :: ED_name_canopy_closure_thresh= "fates_canopy_closure_thresh"      
    character(len=param_string_length),parameter,public :: ED_name_stomatal_model= "fates_leaf_stomatal_model"
+   character(len=param_string_length),parameter,public :: ED_name_dayl_switch= "fates_dayl_switch"
    character(len=param_string_length),parameter,public :: ED_name_regeneration_model= "fates_regeneration_model"
 
    character(len=param_string_length),parameter,public :: name_theta_cj_c3 = "fates_leaf_theta_cj_c3"
@@ -359,6 +361,7 @@ contains
     ED_val_patch_fusion_tol               = nan
     ED_val_canopy_closure_thresh          = nan
     stomatal_model                        = -9
+    dayl_switch                           = -9
     regeneration_model                    = -9
     stomatal_assim_model                  = -9
     maxpatch_primary                      = -9
@@ -510,6 +513,9 @@ contains
          dimension_names=dim_names_scalar)
 
     call fates_params%RegisterParameter(name=ED_name_stomatal_model, dimension_shape=dimension_shape_scalar, &
+         dimension_names=dim_names_scalar)
+
+    call fates_params%RegisterParameter(name=ED_name_dayl_switch, dimension_shape=dimension_shape_scalar, &
          dimension_names=dim_names_scalar)
 	 
     call fates_params%RegisterParameter(name=ED_name_regeneration_model, dimension_shape=dimension_shape_scalar, &
@@ -728,6 +734,10 @@ contains
          data=tmpreal)
     stomatal_model = nint(tmpreal)
 
+    call fates_params%RetrieveParameter(name=ED_name_dayl_switch, &
+         data=tmpreal)
+    dayl_switch = nint(tmpreal)
+
     call fates_params%RetrieveParameter(name=ED_name_regeneration_model, &
          data=tmpreal)
     regeneration_model = nint(tmpreal)
@@ -901,6 +911,7 @@ contains
         write(fates_log(),fmt0) 'ED_val_canopy_closure_thresh = ',ED_val_canopy_closure_thresh
         write(fates_log(),fmt0) 'regeneration_model = ',regeneration_model      
         write(fates_log(),fmt0) 'stomatal_model = ',stomatal_model
+        write(fates_log(),fmt0) 'dayl_switch = ',dayl_switch
         write(fates_log(),fmt0) 'stomatal_assim_model = ',stomatal_assim_model            
         write(fates_log(),fmt0) 'hydro_kmax_rsurf1 = ',hydr_kmax_rsurf1
         write(fates_log(),fmt0) 'hydro_kmax_rsurf2 = ',hydr_kmax_rsurf2  

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -245,6 +245,9 @@ variables:
 	double fates_damage_recovery_scalar(fates_pft) ;
 		fates_damage_recovery_scalar:units = "unitless" ;
 		fates_damage_recovery_scalar:long_name = "fraction of the cohort that recovers from damage" ;
+	double fates_daylength_factor_switch ;
+		fates_daylength_factor_switch:units = "unitless" ;
+		fates_daylength_factor_switch:long_name = "user switch for turning on (1) or off (2) the day length factor scaling for photosynthetic parameters" ;
 	double fates_dev_arbitrary_pft(fates_pft) ;
 		fates_dev_arbitrary_pft:units = "unknown" ;
 		fates_dev_arbitrary_pft:long_name = "Unassociated pft dimensioned free parameter that developers can use for testing arbitrary new hypotheses" ;
@@ -1602,6 +1605,8 @@ data:
  fates_damage_canopy_layer_code = 1 ;
 
  fates_damage_event_code = 1 ;
+
+ fates_daylength_factor_switch = 1 ;
 
  fates_dev_arbitrary = _ ;
 


### PR DESCRIPTION

### Description:
This pull request is adding in a user specified switch to turn on or off the day length scaling factor, that is applied to the photosynthetic parameters Vcmax25 and jmax25. This is to be able to allow backwards compatibility with previous versions of the calibration branch. 
The function daylength is a scaling factor that is based on the formulation in Bauerle et al. (2012), which quantifies the relationship between day length and Jmax. 

### Collaborators:
Greg Lemieux

### Expectation of Answer Changes:
The default is to have the day length factor turned on (equal to 1 in the parameter file), and should have the same results as the most recent calibration branch found here (https://github.com/rgknox/fates/tree/unsupported_sp_calibration_api31)

If turned off, this will change values related to photosynthesis, GPP, and downstream results.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

E3SM test hash-tag: a7f4ecb9dd

E3SM baseline hash-tag: a7f4ecb9dd

FATES baseline hash-tag: [f8bf84c](https://github.com/rgknox/fates/commit/f8bf84c6e8e605bff7db01e0b85da05073effa40)

Test Output:

/pscratch/sd/j/jaholm/e3sm_scratch/pm-cpu/fates_prr_test.pm-cpu.Ea7f4ecb9dd-F4e103117.2023-12-30/run


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

