### PR TITLE
Two stream singularity fix refactor

### DIFF
--- a/radiation/TwoStreamMLPEMod.F90
+++ b/radiation/TwoStreamMLPEMod.F90
@@ -993,8 +993,7 @@ contains
                      call endrun(msg=errMsg(sourcefile, __LINE__))
                   end if
                   ! Test to see if there is a singularity and make corrections if needed
-                  Kb_sing_check(:) = (abs(Kb_sing(:) - Kb_eff)) < sing_tol
-                  if any(Kb_sing_check(:)) then
+                  if any((abs(Kb_sing(:) - Kb_eff)) < sing_tol) then
                      Kb_eff = Kb_eff + sing_tol
                      is_sing = .true.
                   end if


### PR DESCRIPTION
While reviewing this, I noticed that the inputs to `Kb_sing` aren't getting updated inside the `do_test_sing` loop so I tried refactoring this update to pull that computation out of the loop.  I figured it'd be easier to review it this way instead of making a comment in your PR comments.  

**Big caveat:**  I haven't tested this out yet to see if it works or what the performance impact might be.  I'll give it a try tomorrow.  Let me know what you think.