### PR TITLE
Make `check_order` optional and default to `.false.`

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -139,7 +139,7 @@ contains
     ! If we demote -all- the trees less than a given height, there is a massive advantage in being the cohort that is
     ! the biggest when the canopy is closed.
     ! In this implementation, the amount demoted, ('weight') is a function of the height weighted by the competitive exclusion
-    ! parameter (ED_val_comp_excln).
+    ! parameter (comp_excln_exp).
 
     ! Complexity in this routine results from a few things.
     ! Firstly, the complication of the demotion amount sometimes being larger than the cohort area (for a very small, short cohort)

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -1219,7 +1219,7 @@ contains
      endif ! patch.
      
      if (fusion_took_place == 1) then  ! if fusion(s) occured sort cohorts
-        call currentPatch%SortCohorts(check_order=.false.)
+        call currentPatch%SortCohorts()
         call currentPatch%ValidateCohorts()
      endif
    

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1256,7 +1256,7 @@ contains
                             enddo cohortloop
                             call newPatch%ValidateCohorts()
 
-                            call currentPatch%SortCohorts(check_order=.false.)
+                            call currentPatch%SortCohorts()
                             call currentPatch%ValidateCohorts()
 
                             !update area of donor patch
@@ -1288,7 +1288,7 @@ contains
                             call terminate_cohorts(currentSite, currentPatch, 1,16,bc_in)
                             call fuse_cohorts(currentSite,currentPatch, bc_in)
                             call terminate_cohorts(currentSite, currentPatch, 2,16,bc_in)
-                            call currentPatch%SortCohorts(check_order=.false.)
+                            call currentPatch%SortCohorts()
                             call currentPatch%ValidateCohorts()
 
                          end if areadis_gt_zero_if   ! if ( newPatch%area > nearzero ) then
@@ -1316,7 +1316,7 @@ contains
                    call terminate_cohorts(currentSite, newPatch, 1,17, bc_in)
                    call fuse_cohorts(currentSite,newPatch, bc_in)
                    call terminate_cohorts(currentSite, newPatch, 2,17, bc_in)
-                   call newPatch%SortCohorts(check_order=.false.)
+                   call newPatch%SortCohorts()
                    call newPatch%ValidateCohorts()
                 endif
 
@@ -1721,7 +1721,7 @@ contains
     enddo ! currentCohort
     call new_patch%ValidateCohorts()
 
-    call currentPatch%SortCohorts(check_order=.false.)
+    call currentPatch%SortCohorts()
     call currentPatch%ValidateCohorts()
 
     !update area of donor patch
@@ -3023,7 +3023,7 @@ contains
                             tmpptr => currentPatch%older       
                             call fuse_2_patches(csite, currentPatch, tpp)
                             call fuse_cohorts(csite,tpp, bc_in)
-                            call tpp%SortCohorts(check_order=.false.)
+                            call tpp%SortCohorts()
                             call tpp%ValidateCohorts()
                             currentPatch => tmpptr
 

--- a/biogeochem/FatesPatchMod.F90
+++ b/biogeochem/FatesPatchMod.F90
@@ -1173,12 +1173,20 @@ module FatesPatchMod
       ! ARGUMENTS:
       class(fates_patch_type), intent(inout), target :: this ! patch
 
-      logical,intent(in) :: check_order
+      logical, optional, intent(in) :: check_order
       
       ! LOCALS:
       type(fates_cohort_type), pointer :: currentCohort
       type(fates_cohort_type), pointer :: nextCohort
+
+      logical :: check_order_present
       
+      if (present(check_order)) then
+        check_order_present = check_order
+      else
+        check_order_present = .false.
+      end if
+
       ! check for inconsistent list state
       if (.not. associated(this%shortest) .and. .not. associated(this%tallest)) then
           ! empty list
@@ -1192,7 +1200,7 @@ module FatesPatchMod
       ! hold on to current linked list so we don't lose it
       currentCohort => this%shortest
 
-      if(check_order)then
+      if(check_order_present)then
          do while (associated(currentCohort))
             if( associated(currentCohort%taller)) then
                if(currentCohort%height > currentCohort%taller%height)then

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -1341,7 +1341,7 @@ contains
 
       if (hlm_use_sp == ifalse) then
         call fuse_cohorts(site_in, patch_in,bc_in)
-        call patch_in%SortCohorts(check_order=.false.)
+        call patch_in%SortCohorts()
       end if
       
       call patch_in%ValidateCohorts()

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -261,7 +261,7 @@ contains
        do while (associated(currentPatch))
 
           ! puts cohorts in right order
-          call currentPatch%SortCohorts(check_order=.false.)
+          call currentPatch%SortCohorts()
 
           ! kills cohorts that are too few
           call terminate_cohorts(currentSite, currentPatch, 1, 10, bc_in  )

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -429,7 +429,7 @@ contains
 
             ! Perform Cohort Fusion
             call fuse_cohorts(sites(s), currentpatch,bc_in(s))
-            call currentpatch%SortCohorts(check_order=.false.)
+            call currentpatch%SortCohorts()
 
             ! This calculates %num_cohorts
             call currentPatch%CountCohorts()

--- a/testing/unit_testing/sort_cohorts_test/test_SortCohorts.pf
+++ b/testing/unit_testing/sort_cohorts_test/test_SortCohorts.pf
@@ -25,7 +25,7 @@ module test_SortCohorts
       type(fates_patch_type)                 :: patch ! patch object
       
       ! sort cohorts - should pass - the argument
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
               
     end subroutine EmptyList_SortCohorts_Passes
   
@@ -42,7 +42,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights)
       
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! test that the order is correct
       i = 1
@@ -68,7 +68,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights)
       
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! test that the order is correct
       i = size(heights)
@@ -96,7 +96,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights)
         
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! test that the order is correct
       i = 1
@@ -123,7 +123,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights)
       
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! test that the order is correct
       i = size(heights)
@@ -151,7 +151,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights)
       
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! check backwards and forwards
       cohort => patch%shortest
@@ -186,7 +186,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights, dbhs=dbhs)
       
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! test that the order is correct
       i = 1
@@ -223,7 +223,7 @@ module test_SortCohorts
       call CreateTestPatchList(patch, heights, dbhs=dbhs)
     
       ! sort cohorts
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       
       ! test that the order is correct
       i = 1
@@ -266,7 +266,7 @@ module test_SortCohorts
       cohort3%shorter => cohort2
     
       ! should fail
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       @assertExceptionRaised(expected_msg)
       
       ! try the opposite
@@ -274,7 +274,7 @@ module test_SortCohorts
       patch%tallest => cohort3 
       
       ! should also fail
-      call patch%SortCohorts(check_order=.false.)
+      call patch%SortCohorts()
       @assertExceptionRaised(expected_msg)
     
     end subroutine SortCohorts_InconsistentListState_Errors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
The majority of `SortCohorts` calls are currently defaulting to `.false.`.  This makes the `check_order` call an optional call to remove the need to pass an explicit `.false.` argument.

This also makes a minor update to a comment with the new competitive exclusion parameter name.   

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

